### PR TITLE
feat(chapters): auto-include numbered chapter files

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,28 @@
+name: Build and release PDF
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    container:
+      image: texlive/texlive:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build PDF
+        run: latexmk -interaction=nonstopmode -file-line-error
+
+      - name: Create release and upload PDF
+        uses: softprops/action-gh-release@v2
+        with:
+          files: out/main.pdf
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,3 +1,16 @@
+@default_files = ("main.tex");
 $aux_dir = "auxil/";
 $out_dir = "out/";
 $pdf_mode = 1;
+
+# Create aux subdirs for \include{path/file} so .aux writes succeed (e.g. pages/restrictionNotice.aux).
+use File::Path qw(make_path);
+sub ensure_aux_include_dirs {
+  my $aux = $aux_dir || ".";
+  $aux =~ s{[\\/]\z}{};
+  foreach my $subdir (qw(pages content)) {
+    my $path = $aux . "/" . $subdir;
+    make_path($path) unless -d $path;
+  }
+}
+ensure_aux_include_dirs();

--- a/README.md
+++ b/README.md
@@ -1,25 +1,19 @@
 # DHBW-template
-## Description
-This is a template usable for DHBW students.
-It contains everything you need to get started writing your T1000, T2000 or T3000, Bachelor's or Master’s thesis.
 
-Feel free to [open an issue](https://github.com/TobiasGoetz/dhbw-template/issues/new/choose) or [contact me](mailto:dhbw-template@tobiasgoetz.com) if you have any questions, suggestions or improvements.
+LaTeX template for DHBW papers and theses (T1000/T2000/T3000, Bachelor, Master).
 
-## Usage
-### :clipboard: Prerequisites
-- LaTeX distribution (e.g. [MikTeX](https://miktex.org/))
-- [Latexmk](https://mg.readthedocs.io/latexmk.html)
+## Quickstart
+- Edit `config/config.tex` (title, author, dates, language, included sections).
+- Put your logos/images in `images/` (keep `dhbw` and `company` filenames if you replace placeholders).
+- Write chapters in `content/` as `00chapter.tex`, `01chapter.tex`, ... (auto-included).
+- Add references to `bibliography/bibliography.bib`.
+- Build with:
 
-### :gear: Configuration
-- :gear: **Edit files in the `/config` folder** to your liking
-  - `config.tex` contains all the general settings
-  - `chapter.tex` is used to include your chapters, choose which inclusion style you prefer
-- :framed_picture: **Replace images** in the `/images` folder with your own, but make sure to keep the same file names
-- :writing_hand: **Write your chapters** in the `/content` folder
-- :books: **Add your bibliography** to `/bibliography/bibliography.bib`
-
-### :hammer: Build
-To build the document, run the following command in the root directory of the project:
 ```bash
 latexmk
 ```
+
+Build output is written to `out/` (PDF: `out/main.pdf`).
+
+## Releases
+Pushing a tag like `v1.0.0` triggers GitHub Actions to build and publish `out/main.pdf` as a release asset.

--- a/config/chapters.tex
+++ b/config/chapters.tex
@@ -1,15 +1,8 @@
-%%% SELECT EITHER OPTION1 OR OPTION2 %%%
-
-%%% OPTION 1 %%%
-% Include all files in content/ that start with XXchapter where XX is a number from 00 to 99.
-%\foreach \i in {00,01,...,99} {
-%    \edef\FileName{content/\i chapter}%
-%
-%    \IfFileExists{\FileName}{
-%        \include{\FileName}
-%    }
-%}
-
-%%% OPTION 2 %%%
-% Include each file seperately (better package recognition by most IDEs)
-\include{content/00chapter}
+% Include all files in content/ that start with XXchapter (XX = 00, 01, ..., 99).
+\newcommand{\chapterpath}[1]{content/#1chapter}
+\foreach \i in {00,01,02,03,04,05,06,07,08,09,10,...,99} {
+    \edef\FileName{\chapterpath{\i}}%
+    \IfFileExists{\FileName}{
+        \include{\FileName}
+    }
+}

--- a/config/config.tex
+++ b/config/config.tex
@@ -1,23 +1,23 @@
 \newcommand\mylanguage{en} % [en, de]
-\newcommand\mythesisTitle{placeholder} % title of your thesis
-\newcommand\mymatriculationNumber{placeholder} % your matriculation number
-\newcommand\mymajor{placeholder} % Computer Science, Engineering, ...
-\newcommand\myyearabbreviation{placeholder} % e.g. TIM20, TIS21, ...
-\newcommand\mysemester{placeholder} % 1, 2, 3, 4, 5, 6
-\newcommand\mystartDate{placeholder} % date you started your thesis
-\newcommand\mysubmissionDate{placeholder} % date you will submit your thesis
-\newcommand\mycompany{placeholder} % company you worked at
-\newcommand\mycompanyLocation{placeholder} % city of the company
-\newcommand\mysubmissionLocation{placeholder} % city you will submit your thesis
+\newcommand\mythesisTitle{Sample Thesis Title} % title of your thesis
+\newcommand\mymatriculationNumber{1234567} % your matriculation number
+\newcommand\mymajor{Sample Major} % Computer Science, Engineering, ...
+\newcommand\myyearabbreviation{ABC24} % e.g. TIM20, TIS21, ...
+\newcommand\mysemester{1} % 1, 2, 3, 4, 5, 6
+\newcommand\mystartDate{01.01.2026} % date you started your thesis
+\newcommand\mysubmissionDate{31.03.2026} % date you will submit your thesis
+\newcommand\mycompany{Sample Company} % company you work at
+\newcommand\mycompanyLocation{Sample City} % city of the company
+\newcommand\mysubmissionLocation{Sample City} % city you will submit your thesis
 %\newcommand\myphase{placeholder} % optional, can be used for T1000, T2000, T3000 and should say "about the practical phase of the first/second/third year of study"
-\newcommand\mystudyProgram{placeholder}
-\newcommand\mydhbw{placeholder} % Ravensburg, Karlsruhe, Heilbronn
-\newcommand\mycampus{placeholder} % optional, e.g. Friedrichshafen
-\newcommand\mysupervisor{placeholder} % your supervisor
-%\newcommand\myreviewer{placeholder} % optional, your reviewer
-\newcommand\mythesis{placeholder} % T1000, T2000, T3000, Bachelor Thesis, Master Thesis
-\newcommand\myauthor{placeholder} % your name
-\newcommand\myfocus{placeholder} % optional, e.g. Mobile Computer Science, IT-Security, ...
+\newcommand\mystudyProgram{Sample Study Program} % e.g. Informatik, Wirtschaftsinformatik
+\newcommand\mydhbw{Sample Location} % Ravensburg, Karlsruhe, Heilbronn
+\newcommand\mycampus{Sample Campus} % optional, e.g. Friedrichshafen
+\newcommand\mysupervisor{Sample Supervisor} % your supervisor
+\newcommand\myreviewer{Sample Reviewer} % optional, your reviewer
+\newcommand\mythesis{Bachelor Thesis} % T1000, T2000, T3000, Bachelor Thesis, Master Thesis
+\newcommand\myauthor{Sample Author} % your name
+\newcommand\myfocus{Sample Focus} % optional, e.g. Mobile Computer Science, IT-Security, ...
 
 % Literature
 \newcommand\mycitationStyle{authoryear}

--- a/content/00chapter.tex
+++ b/content/00chapter.tex
@@ -1,3 +1,4 @@
+% !TeX root = ../main.tex
 \chapter{Lorem Ipsum}\label{ch:lorem-ipsum}
 This is the first usage of an example acronym: \ac{dhbw}.\\
 This is the second usage of an example acronym: : \ac{dhbw}.\\

--- a/pages/cover.tex
+++ b/pages/cover.tex
@@ -1,8 +1,10 @@
 \begin{titlepage}
+    \ifdefined\mycompany\ifdefined\mycompanyLocation
     \begin{minipage}[t][2.5cm]{0.4\linewidth}
         \raggedright
         \includegraphics[height=2.5cm]{images/company}
     \end{minipage}
+    \fi\fi
     \hfill
     \begin{minipage}[t][2.5cm]{0.4\linewidth}
         \raggedleft
@@ -45,8 +47,12 @@
     \begin{tabular}{ll}
         \langduration:                         & \mystartDate~-~\mysubmissionDate              \\
         \langmatriculationnumber, \langcourse: & \mymatriculationNumber, \myyearabbreviation \\
+        \ifdefined\mycompany\ifdefined\mycompanyLocation
         \langcompany:                          & \mycompany, \mycompanyLocation              \\
+        \fi\fi
+        \ifdefined\mysupervisor
         \langsupervisor:                       & \mysupervisor                               \\
+        \fi
         \ifdefined\myreviewer
         \langreviewer:                         & \myreviewer                                 \\
         \fi


### PR DESCRIPTION
Switch chapter inclusion to automatic discovery of 00-99 chapter files and add a TeX root hint in the sample chapter for better editor integration.

Made-with: Cursor